### PR TITLE
[DPE-7466] Standalone Opensearch rock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: Upload built rock job artifact
         uses: actions/upload-artifact@v4
         with:
-          name: charmed_opensearch_rock_amd64
-          path: "charmed-opensearch_*.rock"
+          name: opensearch_rock_amd64
+          path: "opensearch_*.rock"
 
   scan:
     name: Trivy scan and sbom generation
@@ -51,7 +51,7 @@ jobs:
       - name: Download rock file
         uses: actions/download-artifact@v4
         with:
-          name: charmed_opensearch_rock_amd64
+          name: opensearch_rock_amd64
           path: .
 
       - name: Install required dependencies
@@ -74,13 +74,13 @@ jobs:
           sudo skopeo \
               --insecure-policy \
               copy \
-              oci-archive:charmed-opensearch_${version}_amd64.rock \
-              docker-daemon:trivy/charmed_opensearch_rock_amd64:test
+              oci-archive:opensearch_${version}_amd64.rock \
+              docker-daemon:trivy/opensearch_rock_amd64:test
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.30.0
         with:
-          image-ref: 'trivy/charmed_opensearch_rock_amd64:test'
+          image-ref: 'trivy/opensearch_rock_amd64:test'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
@@ -97,7 +97,7 @@ jobs:
           scan-type: 'image'
           format: 'spdx-json'
           output: 'dependency-results.sbom.json'
-          image-ref: 'trivy/charmed_opensearch_rock_amd64:test'
+          image-ref: 'trivy/opensearch_rock_amd64:test'
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: "MEDIUM,HIGH,CRITICAL"
           scanners: "vuln"
@@ -122,7 +122,7 @@ jobs:
       - name: Download rock file
         uses: actions/download-artifact@v4
         with:
-          name: charmed_opensearch_rock_amd64
+          name: opensearch_rock_amd64
           path: .
 
       - name: Install required dependencies
@@ -146,8 +146,8 @@ jobs:
           sudo skopeo \
               --insecure-policy \
               copy \
-              oci-archive:charmed-opensearch_${version}_amd64.rock \
-              docker-daemon:charmed-opensearch:${version}
+              oci-archive:opensearch_${version}_amd64.rock \
+              docker-daemon:opensearch:${version}
 
       - name: Setup the required system configs
         run: |
@@ -166,7 +166,7 @@ jobs:
               -e INITIAL_CM_NODES=cm0 \
               -p 9200:9200 \
               --name cm0 \
-              charmed-opensearch:"${version}")
+              opensearch:"${version}")
           container_0_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_0_id}")
           
           # wait a bit for it to fully initialize
@@ -180,7 +180,7 @@ jobs:
               -e NODE_ROLES=data,voting_only \
               -p 9201:9200 \
               --name data1 \
-              charmed-opensearch:"${version}")
+              opensearch:"${version}")
           container_1_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_1_id}")
           
           # wait a bit for it to fully initialize
@@ -194,7 +194,7 @@ jobs:
               -e INITIAL_CM_NODES="cm0,cm1" \
               -p 9202:9200 \
               --name cm1 \
-              charmed-opensearch:"${version}")
+              opensearch:"${version}")
           container_2_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_2_id}")
           
           # wait a bit for it to fully initialize

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - 2/edge
+      - 2-24.04/edge
 
 jobs:
   ci-tests:
@@ -42,7 +42,7 @@ jobs:
       - name: Download rock file
         uses: actions/download-artifact@v4
         with:
-          name: charmed_opensearch_rock_amd64
+          name: opensearch_rock_amd64
           path: .
 
       - name: Login to GitHub Container Registry
@@ -64,16 +64,16 @@ jobs:
           sudo skopeo \
               --insecure-policy \
               copy \
-              oci-archive:charmed-opensearch_${version}_amd64.rock \
-              docker-daemon:ghcr.io/canonical/charmed-opensearch:${major_tag_version}
-          docker push ghcr.io/canonical/charmed-opensearch:${major_tag_version}
+              oci-archive:opensearch_${version}_amd64.rock \
+              docker-daemon:ghcr.io/canonical/opensearch:${major_tag_version}
+          docker push ghcr.io/canonical/opensearch:${major_tag_version}
           
           ### push full version to edge
           tag_version="${version}-${base}_${{ env.RELEASE }}"
-          echo "Publishing charmed-opensearch:${tag_version}"
+          echo "Publishing opensearch:${tag_version}"
           sudo skopeo \
               --insecure-policy \
               copy \
-              oci-archive:charmed-opensearch_${version}_amd64.rock \
-              docker-daemon:ghcr.io/canonical/charmed-opensearch:${tag_version}
-          docker push ghcr.io/canonical/charmed-opensearch:${tag_version}
+              oci-archive:opensearch_${version}_amd64.rock \
+              docker-daemon:ghcr.io/canonical/opensearch:${tag_version}
+          docker push ghcr.io/canonical/opensearch:${tag_version}

--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
-## Introduction to Charmed OpenSearch Rock (OCI Image)
-[![Publish](https://github.com/canonical/charmed-opensearch-rock/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/charmed-opensearch-rock/actions/workflows/release.yaml)
-[![Build and Test](https://github.com/canonical/charmed-opensearch-rock/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/charmed-opensearch-rock/actions/workflows/ci.yaml)
+## Introduction to OpenSearch Rock (OCI Image)
+[![Publish](https://github.com/canonical/opensearch-rock/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/opensearch-rock/actions/workflows/release.yaml)
+[![Build and Test](https://github.com/canonical/opensearch-rock/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/opensearch-rock/actions/workflows/ci.yaml)
 
 [OpenSearch](https://opensearch.org/) is an open-source search and analytics suite. 
 Developers build solutions for search, data observability, data ingestion and more using OpenSearch. 
 OpenSearch is offered under the Apache Software Licence, version 2.0.
 
-[Charmed OpenSearch rock](https://github.com/canonical/charmed-opensearch-rock/pkgs/container/charmed-opensearch) 
-is an Open Container Initiative (OCI) image derived from the [Charmed OpenSearch Snap](https://snapcraft.io/opensearch). 
+[OpenSearch rock](https://github.com/canonical/opensearch-rock/pkgs/container/opensearch) 
+is an Open Container Initiative (OCI) image derived from the [OpenSearch Snap](https://snapcraft.io/opensearch). 
 The tool used to create this rock is called [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/index.html).
 
-This repository contains the packaging metadata for creating a Charmed OpenSearch rock. This rock image is based on the [OpenSearch Snap](https://github.com/canonical/opensearch-snap)
+This repository contains the packaging metadata for creating a OpenSearch rock. This rock image is based on the [OpenSearch Snap](https://github.com/canonical/opensearch-snap)
 
 For more information on rocks, visit the [rockcraft Github](https://github.com/canonical/rockcraft).
 
 ## Version
-The Charmed OpenSearch rock release aligns with the [OpenSearch upstream major version](https://opensearch.org/docs/latest/version-history/) naming. OpenSearch releases major versions such as 1.0, 2.0, and so on.
-
-## Release
-Charmed OpenSearch [Rock Release Notes](https://discourse.charmhub.io/t/release-notes-charmed-opensearch-2-rock/10278).
-
+The OpenSearch rock release aligns with the [OpenSearch upstream major version](https://opensearch.org/docs/latest/version-history/) naming. OpenSearch releases major versions such as 1.0, 2.0, and so on.
 
 ## Rock Usage
 ### Building the Rock
@@ -34,8 +30,8 @@ multipass shell rock-dev
 
 #### Clone Repository
 ```bash
-git clone https://github.com/canonical/charmed-opensearch-rock.git
-cd charmed-opensearch-rock
+git clone https://github.com/canonical/opensearch-rock.git
+cd opensearch-rock
 ```
 #### Installing Prerequisites
 ```bash
@@ -58,8 +54,8 @@ version="$(cat rockcraft.yaml | yq .version)"
 
 sudo skopeo --insecure-policy \
   copy \
-  oci-archive:charmed-opensearch_"${version}"_amd64.rock \
-  docker-daemon:charmed-opensearch:"${version}"
+  oci-archive:opensearch_"${version}"_amd64.rock \
+  docker-daemon:opensearch:"${version}"
 
 docker run \
   -d --rm -it \
@@ -67,7 +63,7 @@ docker run \
   -e INITIAL_CM_NODES=cm0 \
   -p 9200:9200 \
   --name cm0 \
-  charmed-opensearch:"${version}"
+  opensearch:"${version}"
 ```
 
 ### Testing a multi nodes deployment:
@@ -79,7 +75,7 @@ container_0_id=$(docker run \
   -e INITIAL_CM_NODES=cm0 \
   -p 9200:9200 \
   --name cm0 \
-  charmed-opensearch:"${version}")
+  opensearch:"${version}")
 container_0_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_0_id}")
 
 # wait a bit for it to fully initialize
@@ -93,7 +89,7 @@ container_1_id=$(docker run \
     -e NODE_ROLES=data,voting_only \
     -p 9201:9200 \
     --name data1 \
-    charmed-opensearch:"${version}")
+    opensearch:"${version}")
 container_1_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_1_id}")
 
 # wait a bit for it to fully initialize
@@ -107,7 +103,7 @@ container_2_id=$(docker run \
     -e INITIAL_CM_NODES="cm0,cm1" \
     -p 9202:9200 \
     --name cm1 \
-    charmed-opensearch:"${version}")
+    opensearch:"${version}")
 
 # wait a bit for it to fully initialize
 sleep 15s
@@ -122,7 +118,7 @@ And expect to see 3 nodes.
 **NOTE:** This deployment IS NOT suitable for production AS IS. As this deployment disables and does NOT configure the security of OpenSearch. Please use it as part of the Juju OpenSearch K8s charm once ready.
 
 ## License
-The Charmed OpenSearch rock is free software, distributed under the Apache
+The OpenSearch rock is free software, distributed under the Apache
 Software License, version 2.0. See
 [LICENSE](https://github.com/canonical/opensearch-rock/blob/main/licenses)
 for more information.
@@ -130,14 +126,14 @@ for more information.
 
 ## Security, Bugs and feature request
 If you find a bug in this rock or want to request a specific feature, here are the useful links:
-- Raise the issue or feature request in the [Canonical GitHub repository](https://github.com/canonical/charmed-opensearch-rock/issues).
+- Raise the issue or feature request in the [Canonical GitHub repository](https://github.com/canonical/opensearch-rock/issues).
 - Meet the community and chat with us if there are issues and feature requests in our [Mattermost Channel](https://chat.charmhub.io/charmhub/channels/data-platform).
 
 ## Contributing
 Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/mongodb-operator/blob/main/CONTRIBUTING.md) for developer guidance.
 
 ## Trademark notice
-OpenSearch is a registered trademark of Amazon Web Services. Other trademarks are property of their respective owners. Charmed OpenSearch is not sponsored, endorsed, or affiliated with Amazon Web Services.
+OpenSearch is a registered trademark of Amazon Web Services. Other trademarks are property of their respective owners. OpenSearch is not sponsored, endorsed, or affiliated with Amazon Web Services.
 
 ## License
-The Charmed OpenSearch rock, Charmed OpenSearch Snap, and Charmed OpenSearch Operator are free software, distributed under the [Apache Software License, version 2.0](https://github.com/canonical/charmed-opensearch-rock/blob/main/licenses/LICENSE-rock). They install and operate OpenSearch, which is also licensed under the [Apache Software License, version 2.0](https://github.com/canonical/charmed-opensearch-rock/blob/main/licenses/LICENSE-opensearch).
+The OpenSearch rock, OpenSearch Snap, and OpenSearch Operator are free software, distributed under the [Apache Software License, version 2.0](https://github.com/canonical/opensearch-rock/blob/main/licenses/LICENSE-rock). They install and operate OpenSearch, which is also licensed under the [Apache Software License, version 2.0](https://github.com/canonical/opensearch-rock/blob/main/licenses/LICENSE-opensearch).

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,12 +1,12 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: charmed-opensearch # the name of your ROCK
+name: opensearch # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
 
 version: '2.19.1' # just for humans. Semantic versioning is recommended
 
-summary: 'Charmed OpenSearch ROCK OCI.'
+summary: 'OpenSearch ROCK OCI.'
 description: |
   OpenSearch is a community-driven, Apache 2.0-licensed open source search and 
   analytics suite that makes it easy to ingest, search, visualize, and analyze data. 
@@ -48,7 +48,7 @@ parts:
   opensearch-snap:
     plugin: nil
     stage-snaps:
-      - opensearch/2/edge
+      - opensearch/2/edge/dpe-7400
     stage-packages:
       - base-files
       - python3-venv

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ container_0_id=$(docker run \
     -e INITIAL_CM_NODES=cm0 \
     -p 9200:9200 \
     --name cm0 \
-    charmed-opensearch:"${version}")
+    opensearch:"${version}")
 container_0_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_0_id}")
 
 # wait a bit for it to fully initialize
@@ -23,7 +23,7 @@ container_1_id=$(docker run \
     -e NODE_ROLES=data,voting_only \
     -p 9201:9200 \
     --name data1 \
-    charmed-opensearch:"${version}")
+    opensearch:"${version}")
 container_1_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_1_id}")
 
 # wait a bit for it to fully initialize
@@ -37,7 +37,7 @@ docker run \
     -e INITIAL_CM_NODES="cm0,cm1" \
     -p 9202:9200 \
     --name cm1 \
-    charmed-opensearch:"${version}"
+    opensearch:"${version}"
 
 # wait a bit for it to fully initialize
 sleep 15s


### PR DESCRIPTION
This PR:
- changes the name to `opensearch-rock`
- uses an opensearch-snap without the prometheus-exporter plugins and plugins with the 'repository-' prefix
- changes the release workflow to trigger on 2-24.04/edge branch